### PR TITLE
Fix typo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
 
   pullImage:
     description: "Repull every images"
-    required: fasle
+    required: false
     default: false
 
   delete:


### PR DESCRIPTION
Can't use the input otherwise: cannot unmarshal !!str `fasle` into bool
